### PR TITLE
fix: harden tor-39 runtime and auth boundaries

### DIFF
--- a/.agents/notes/dist-shadowing.md
+++ b/.agents/notes/dist-shadowing.md
@@ -1,0 +1,5 @@
+# Dist Shadowing
+
+- Built `dist/**` artifacts can mask missing or stale `src/**` modules during Bun-driven test runs and package builds. In this repo, `packages/api/src/features/game/session-join.ts` was missing from source while imports still resolved against an old `packages/api/dist/src/features/game/session-join.js`.
+- This matters because refactors can appear to work until typecheck or a clean build touches the source graph. When a source import behaves impossibly, check for a stale compiled twin under `dist/**` before assuming TypeScript or Bun path resolution is wrong.
+- After moving or recreating source modules, rerun focused tests plus `check-types` so the source tree, not the compiled residue, is what keeps the build green.

--- a/.agents/notes/index.md
+++ b/.agents/notes/index.md
@@ -11,3 +11,4 @@
 [game-session-contract.md](./game-session-contract.md) Keep `@reaping/redis` surface minimal, own key/TTL policy there, and preserve the shared phase enum once TOR-36 aligns to it.
 [bun-optional-runtime-imports.md](./bun-optional-runtime-imports.md) Hide optional runtime-only imports behind an extra indirection in Bun tests or the module can still resolve too early and break test overrides.
 [bun-optional-runtime-imports.md](./bun-optional-runtime-imports.md) Bun can eagerly resolve optional runtime imports during test loading; hide them behind an extra indirection for hermetic tests.
+[dist-shadowing.md](./dist-shadowing.md) Stale `dist/**` artifacts can mask missing `src/**` modules and make Bun resolution look impossible.

--- a/apps/server/src/app.smoke.test.ts
+++ b/apps/server/src/app.smoke.test.ts
@@ -28,6 +28,7 @@ describe("app smoke", () => {
 
     const app = createApp({
       corsOrigin: process.env.CORS_ORIGIN ?? "http://localhost:3000",
+      allowTestAuthHeaders: true,
     })
 
     server = Bun.serve({

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -11,11 +11,8 @@ if (import.meta.main) {
   const launch = Effect.gen(function* () {
     void aiModelSelection
     const port = yield* Config.integer("PORT").pipe(Config.withDefault(3000))
-    yield* Effect.sync(() =>
-      app.listen(port, () => {
-        console.log(`Server is running on http://localhost:${port}`)
-      }),
-    )
+    const server = yield* Effect.sync(() => app.listen(port))
+    yield* Effect.log(`Server is running on http://localhost:${server.server?.hostname ?? "localhost"}:${port}`)
   })
 
   await Effect.runPromise(launch)

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,17 +1,11 @@
-import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 
-import { authClient } from "@/modules/auth/auth-client";
+import { getServerSession } from "@/modules/auth/auth-server";
 
 import Dashboard from "./dashboard";
 
 export default async function DashboardPage() {
-  const session = await authClient.getSession({
-    fetchOptions: {
-      headers: await headers(),
-      throw: true,
-    },
-  });
+  const session = await getServerSession();
 
   if (!session?.user) {
     redirect("/login");

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -11,8 +11,6 @@ import {
   CardTitle,
 } from "@/modules/ui/8bit";
 
-export const dynamic = "force-dynamic";
-
 export default async function Home() {
   return (
     <main className="hud-grid min-h-full px-4 py-8 md:px-8">

--- a/apps/web/src/modules/api/eden.server-core.ts
+++ b/apps/web/src/modules/api/eden.server-core.ts
@@ -1,3 +1,5 @@
+import "server-only"
+
 import { treaty } from "@elysiajs/eden"
 import { createApp } from "@reaping/api"
 import { env } from "@reaping/env/server"

--- a/apps/web/src/modules/api/eden.server.test.ts
+++ b/apps/web/src/modules/api/eden.server.test.ts
@@ -8,6 +8,8 @@ const applyServerRuntimeEnv = () => {
 
   runtimeEnv.DATABASE_URL = "postgresql://demo:demo@localhost:5432/reaping"
   runtimeEnv.DATABASE_URL_DIRECT = "postgresql://demo:demo@localhost:5432/reaping"
+  runtimeEnv.UPSTASH_REDIS_REST_URL = "https://example.upstash.io"
+  runtimeEnv.UPSTASH_REDIS_REST_TOKEN = "test-upstash-token"
   runtimeEnv.BETTER_AUTH_SECRET = "12345678901234567890123456789012"
   runtimeEnv.BETTER_AUTH_URL = "http://localhost:3000"
   runtimeEnv.CORS_ORIGIN = "http://localhost:3001"
@@ -27,6 +29,7 @@ afterEach(() => {
 describe("server Eden transport", () => {
   test("uses the in-process app instead of network fetch", async () => {
     applyServerRuntimeEnv()
+    mock.module("server-only", () => ({}))
 
     const networkFetch = mock(() => {
       throw new Error("network fetch should not be called")

--- a/apps/web/src/modules/auth/auth-server.ts
+++ b/apps/web/src/modules/auth/auth-server.ts
@@ -1,0 +1,8 @@
+import "server-only";
+
+import { getAuthSessionFromHeaders } from "@reaping/auth";
+import { headers } from "next/headers";
+
+export async function getServerSession() {
+  return getAuthSessionFromHeaders(new Headers(await headers()));
+}

--- a/packages/api/src/features/demo/routes.ts
+++ b/packages/api/src/features/demo/routes.ts
@@ -1,7 +1,6 @@
-import { Effect } from "effect"
 import { Elysia, status, t } from "elysia"
 
-import { AppRuntime } from "../../runtime.js"
+import { runAppEffect } from "../../modules/http/run-effect.js"
 import {
   DemoDatabaseUnavailableError,
   DemoItemNotFoundError,
@@ -49,12 +48,7 @@ export const demoRoutes = new Elysia({ prefix: "/api/demo" })
   .get(
     "/items/:id",
     async ({ params }) => {
-      const result = await Effect.runPromise(
-        DemoService.getDemoItem(params.id).pipe(
-          Effect.either,
-          Effect.provide(AppRuntime),
-        ),
-      )
+      const result = await runAppEffect(DemoService.getDemoItem(params.id))
 
       if (result._tag === "Left") {
         if (result.left._tag === "DemoItemNotFound") {
@@ -83,12 +77,7 @@ export const demoRoutes = new Elysia({ prefix: "/api/demo" })
   .get(
     "/db",
     async () => {
-      const result = await Effect.runPromise(
-        DemoService.checkDatabase().pipe(
-          Effect.either,
-          Effect.provide(AppRuntime),
-        ),
-      )
+      const result = await runAppEffect(DemoService.checkDatabase())
 
       if (result._tag === "Left") {
         return status(500, toDatabasePayload(result.left))

--- a/packages/api/src/features/demo/service.ts
+++ b/packages/api/src/features/demo/service.ts
@@ -1,4 +1,4 @@
-import { Effect } from "effect"
+import { Config, Effect } from "effect"
 import { pingDatabaseEffect, withDatabase } from "@reaping/db"
 
 import { DemoDatabaseUnavailableError, DemoItemNotFoundError } from "./errors.js"
@@ -13,19 +13,23 @@ export class DemoService extends Effect.Service<DemoService>()("DemoService", {
   accessors: true,
   effect: Effect.gen(function* () {
     const checkDatabase = Effect.fn("DemoService.checkDatabase")(function* () {
-      if (process.env.NODE_ENV === "test") {
+      const nodeEnv = yield* Config.string("NODE_ENV").pipe(
+        Config.withDefault("development"),
+        Effect.orDie,
+      )
+
+      if (nodeEnv === "test") {
         return { healthy: true }
       }
 
       yield* withDatabase(
         pingDatabaseEffect.pipe(
           Effect.map(() => "ok"),
-          Effect.catchAll((error) =>
-            Effect.fail(
+          Effect.mapError(
+            (error) =>
               new DemoDatabaseUnavailableError({
                 message: String(error),
               }),
-            ),
           ),
         ),
       )

--- a/packages/api/src/features/game/betting.test.ts
+++ b/packages/api/src/features/game/betting.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 
 import {
+  type GameSessionStoreClient,
   createGameSession,
   resetGameSessionsForTests,
   type GameSessionEnvelope,
@@ -19,7 +20,7 @@ import {
   InsufficientAvailableBalanceError,
   ParticipantIneligibleToBetError,
 } from "./errors.js";
-import { joinGameSession } from "./session-join.js";
+import { createSessionJoinApi, joinGameSession } from "./session-join.js";
 
 function createEnvelope(input: {
   sessionId: string;
@@ -348,6 +349,167 @@ describe("game betting lifecycle", () => {
     expect(economy.participant?.walletBalance).toBe(joined.walletBalance - 75 + 50);
     expect(economy.participant?.availableBalance).toBe(joined.walletBalance - 75 + 50);
     expect(economy.economyEvents.map((event) => event.type)).toContain("round-settled");
+  });
+
+  test("keeps settlement summaries accurate when a CAS retry occurs", async () => {
+    const sessionId = "session-retry";
+    let envelope = createEnvelope({ sessionId });
+    let shouldConflict = true;
+
+    const store: Pick<
+      GameSessionStoreClient,
+      "createGameSession" | "getGameSession" | "updateGameSession"
+    > = {
+      createGameSession: async (nextEnvelope) => {
+        envelope = nextEnvelope;
+        return envelope;
+      },
+      getGameSession: async (requestedSessionId) =>
+        requestedSessionId === sessionId ? structuredClone(envelope) : null,
+      updateGameSession: async ({ sessionId: requestedSessionId, expectedVersion, update }) => {
+        if (requestedSessionId !== sessionId) {
+          throw new Error(`unexpected session "${requestedSessionId}"`);
+        }
+
+        if (envelope.version !== expectedVersion) {
+          throw new Error("version mismatch");
+        }
+
+        const nextEnvelope = update(structuredClone(envelope));
+
+        if (shouldConflict) {
+          shouldConflict = false;
+          envelope = {
+            ...envelope,
+            version: envelope.version + 1,
+          };
+          throw new Error("version mismatch");
+        }
+
+        envelope = nextEnvelope;
+        return structuredClone(envelope);
+      },
+    };
+
+    const bettingApi = createBettingApi(store);
+    const sessionJoinApi = createSessionJoinApi(store);
+
+    await bettingApi.ensureGameSession(sessionId);
+    await sessionJoinApi.joinGameSession({
+      sessionId,
+      userId: "user-retry",
+      joinedAt: "2026-03-10T12:30:00.000Z",
+      random: createRandomSequence([0.75, 0.25]),
+    });
+    await bettingApi.openBettingWindow({
+      sessionId,
+      openedAt: "2026-03-10T12:30:10.000Z",
+      playerHp: 4,
+      aiHp: 5,
+      magazine: {
+        liveRounds: 2,
+        blankRounds: 3,
+      },
+    });
+    await bettingApi.placeBet({
+      sessionId,
+      userId: "user-retry",
+      requestId: "req-retry-win",
+      betId: "player-survives-round",
+      amount: 100,
+      placedAt: "2026-03-10T12:30:11.000Z",
+    });
+
+    const settled = await bettingApi.settleRoundBets({
+      sessionId,
+      settledAt: "2026-03-10T12:30:20.000Z",
+      outcome: {
+        playerSurvivedRound: true,
+        playerDiedThisRound: false,
+        aiSurvivedRound: true,
+        aiDiedThisRound: false,
+        aiUsedEject: false,
+        playerShotSelf: false,
+        playerShotOpponent: true,
+        nextShotWasLive: true,
+        nextShotWasBlank: false,
+        playerEndingHp: 4,
+        roundTurnCount: 2,
+        noDamageOccurred: false,
+        bothSidesTookDamage: false,
+      },
+    });
+
+    expect(settled.summary).toEqual({
+      settledBetCount: 1,
+      winningBetCount: 1,
+      losingBetCount: 0,
+    });
+  });
+
+  test("preserves participants after fractional payouts", async () => {
+    await createGameSession(createEnvelope({ sessionId: "session-fractional" }));
+
+    const joined = await joinGameSession({
+      sessionId: "session-fractional",
+      userId: "user-fractional",
+      joinedAt: "2026-03-10T12:40:00.000Z",
+      random: createRandomSequence([0.75, 0.25]),
+    });
+
+    await openBettingWindow({
+      sessionId: "session-fractional",
+      openedAt: "2026-03-10T12:40:10.000Z",
+      playerHp: 4,
+      aiHp: 5,
+      magazine: {
+        liveRounds: 2,
+        blankRounds: 3,
+      },
+    });
+
+    await placeBet({
+      sessionId: "session-fractional",
+      userId: "user-fractional",
+      requestId: "req-fractional",
+      betId: "player-shoots-opponent",
+      amount: 11,
+      placedAt: "2026-03-10T12:40:11.000Z",
+    });
+
+    await settleRoundBets({
+      sessionId: "session-fractional",
+      settledAt: "2026-03-10T12:40:20.000Z",
+      outcome: {
+        playerSurvivedRound: true,
+        playerDiedThisRound: false,
+        aiSurvivedRound: true,
+        aiDiedThisRound: false,
+        aiUsedEject: false,
+        playerShotSelf: false,
+        playerShotOpponent: true,
+        nextShotWasLive: false,
+        nextShotWasBlank: true,
+        playerEndingHp: 4,
+        roundTurnCount: 3,
+        noDamageOccurred: false,
+        bothSidesTookDamage: false,
+      },
+    });
+
+    const economy = await getEconomySnapshot({
+      sessionId: "session-fractional",
+      userId: "user-fractional",
+    });
+
+    expect(economy.participant).not.toBeNull();
+
+    if (economy.participant === null) {
+      throw new Error("participant missing after fractional payout");
+    }
+
+    expect(economy.participant.walletBalance).toBe(joined.walletBalance + 3.3);
+    expect(economy.participant.availableBalance).toBe(joined.walletBalance + 3.3);
   });
 });
 

--- a/packages/api/src/features/game/betting.ts
+++ b/packages/api/src/features/game/betting.ts
@@ -324,7 +324,7 @@ export function createBettingApi(store: BettingStore) {
     },
     settleRoundBets: async (input: SettleRoundBetsInput): Promise<SettleRoundBetsResult> => {
       const settledAt = input.settledAt ?? new Date().toISOString();
-      let summary: SettlementSummary = {
+      const emptySummary: SettlementSummary = {
         settledBetCount: 0,
         winningBetCount: 0,
         losingBetCount: 0,
@@ -335,14 +335,21 @@ export function createBettingApi(store: BettingStore) {
       if (current.activeBets.length === 0) {
         return {
           economy: buildEconomySnapshot(current, null),
-          summary,
+          summary: emptySummary,
         };
       }
 
+      let committedSummary: SettlementSummary | null = null;
       const envelope = await updateEnvelopeWithRetries(store, input.sessionId, (session) => {
+        const summary: SettlementSummary = {
+          settledBetCount: 0,
+          winningBetCount: 0,
+          losingBetCount: 0,
+        };
         const activeBets = parsePlacedBets(session.activeBets);
 
         if (activeBets.length === 0) {
+          committedSummary = emptySummary;
           return session;
         }
 
@@ -414,6 +421,7 @@ export function createBettingApi(store: BettingStore) {
         }
 
         summary.settledBetCount = activeBets.length;
+        committedSummary = summary;
 
         const nextParticipants = session.participants.map((participantValue) => {
           const userId = typeof participantValue.userId === "string" ? participantValue.userId : null;
@@ -452,9 +460,13 @@ export function createBettingApi(store: BettingStore) {
         };
       });
 
+      if (committedSummary === null) {
+        throw new Error("settlement summary was not produced");
+      }
+
       return {
         economy: buildEconomySnapshot(envelope, null),
-        summary,
+        summary: committedSummary,
       };
     },
     getEconomySnapshot: async (input: {

--- a/packages/api/src/features/game/routes.ts
+++ b/packages/api/src/features/game/routes.ts
@@ -1,8 +1,8 @@
 import { Effect } from "effect";
 import { Elysia, status, t } from "elysia";
 
+import { runAppEffect } from "../../modules/http/run-effect.js";
 import { resolveAuthUserFromRequest } from "../../modules/http/auth-plugin.js";
-import { AppRuntime } from "../../runtime.js";
 import { DEFAULT_GAME_SESSION_ID } from "./betting.js";
 import {
   BetAmountTooLowError,
@@ -126,8 +126,9 @@ const runtimeErrorSchema = t.Object({
 export const gameRoutes = new Elysia({ prefix: "/api/game" })
   .post(
     "/session/join",
-    async ({ request }) => {
-      const authUser = await resolveAuthUserFromRequest(request);
+    async (context) => {
+      const authOptions = getAuthOptions(context);
+      const authUser = await resolveAuthUserFromRequest(context.request, authOptions);
 
       if (authUser === null) {
         return status(401, {
@@ -170,8 +171,9 @@ export const gameRoutes = new Elysia({ prefix: "/api/game" })
   )
   .get(
     "/economy",
-    async ({ request }) => {
-      const authUser = await resolveAuthUserFromRequest(request);
+    async (context) => {
+      const authOptions = getAuthOptions(context);
+      const authUser = await resolveAuthUserFromRequest(context.request, authOptions);
 
       if (authUser === null) {
         return status(401, {
@@ -219,8 +221,9 @@ export const gameRoutes = new Elysia({ prefix: "/api/game" })
   )
   .post(
     "/bets",
-    async ({ body, request }) => {
-      const authUser = await resolveAuthUserFromRequest(request);
+    async (context) => {
+      const authOptions = getAuthOptions(context);
+      const authUser = await resolveAuthUserFromRequest(context.request, authOptions);
 
       if (authUser === null) {
         return status(401, {
@@ -233,9 +236,9 @@ export const gameRoutes = new Elysia({ prefix: "/api/game" })
         GameService.placeBet({
           sessionId: DEFAULT_GAME_SESSION_ID,
           userId: authUser.id,
-          requestId: body.requestId,
-          betId: body.betId,
-          amount: body.amount,
+          requestId: context.body.requestId,
+          betId: context.body.betId,
+          amount: context.body.amount,
         }),
       );
 
@@ -316,10 +319,13 @@ function mapGameError(
 function runGameEffect<A, E>(
   effect: Effect.Effect<A, E, GameService>,
 ) {
-  return Effect.runPromise(
-    effect.pipe(
-      Effect.either,
-      Effect.provide(AppRuntime),
-    ),
-  );
+  return runAppEffect(effect);
+}
+
+function getAuthOptions(context: object) {
+  return (context as {
+    authOptions?: {
+      allowTestAuthHeaders?: boolean;
+    };
+  }).authOptions;
 }

--- a/packages/api/src/features/game/service.ts
+++ b/packages/api/src/features/game/service.ts
@@ -1,15 +1,18 @@
 import { Effect } from "effect";
-import { GameSessionStore, type GameSessionStoreClient } from "@reaping/redis";
 
 import {
   DEFAULT_GAME_SESSION_ID,
-  createBettingApi,
+  ensureGameSession,
+  getEconomySnapshot as getEconomySnapshotAsync,
   type EconomySnapshot,
   type OpenBettingWindowInput,
+  openBettingWindow as openBettingWindowAsync,
   type PlaceBetInput,
   type PlaceBetResult,
+  placeBet as placeBetAsync,
   type SettleRoundBetsInput,
   type SettleRoundBetsResult,
+  settleRoundBets as settleRoundBetsAsync,
 } from "./betting.js";
 import {
   BetAmountTooLowError,
@@ -23,7 +26,7 @@ import {
   ParticipantNotFoundError,
 } from "./errors.js";
 import {
-  createSessionJoinApi,
+  joinGameSession,
   type JoinGameSessionInput,
 } from "./session-join.js";
 import type { ParticipantWalletState } from "./wallet.js";
@@ -41,46 +44,40 @@ type GameServiceError =
 
 export class GameService extends Effect.Service<GameService>()("GameService", {
   accessors: true,
-  dependencies: [GameSessionStore.Default],
   effect: Effect.gen(function* () {
-    const gameSessionStore = yield* GameSessionStore;
-    const sessionStoreClient = createSessionStoreClient(gameSessionStore);
-    const bettingApi = createBettingApi(sessionStoreClient);
-    const sessionJoinApi = createSessionJoinApi(sessionStoreClient);
-
     const ensureSession = Effect.fn("GameService.ensureSession")(function* (
       sessionId = DEFAULT_GAME_SESSION_ID,
     ) {
-      return yield* tryGamePromise(() => bettingApi.ensureGameSession(sessionId));
+      return yield* tryGamePromise(() => ensureGameSession(sessionId));
     });
 
     const joinSession = Effect.fn("GameService.joinSession")(function* (
       input: JoinGameSessionInput,
     ) {
-      return yield* tryGamePromise(() => sessionJoinApi.joinGameSession(input));
+      return yield* tryGamePromise(() => joinGameSession(input));
     });
 
     const getEconomySnapshot = Effect.fn("GameService.getEconomySnapshot")(function* (input: {
       sessionId: string;
       userId: string | null;
     }) {
-      return yield* tryGamePromise(() => bettingApi.getEconomySnapshot(input));
+      return yield* tryGamePromise(() => getEconomySnapshotAsync(input));
     });
 
     const placeBet = Effect.fn("GameService.placeBet")(function* (input: PlaceBetInput) {
-      return yield* tryGamePromise(() => bettingApi.placeBet(input));
+      return yield* tryGamePromise(() => placeBetAsync(input));
     });
 
     const openBettingWindow = Effect.fn("GameService.openBettingWindow")(function* (
       input: OpenBettingWindowInput,
     ) {
-      return yield* tryGamePromise(() => bettingApi.openBettingWindow(input));
+      return yield* tryGamePromise(() => openBettingWindowAsync(input));
     });
 
     const settleRoundBets = Effect.fn("GameService.settleRoundBets")(function* (
       input: SettleRoundBetsInput,
     ) {
-      return yield* tryGamePromise(() => bettingApi.settleRoundBets(input));
+      return yield* tryGamePromise(() => settleRoundBetsAsync(input));
     });
 
     return {
@@ -112,22 +109,10 @@ export class GameService extends Effect.Service<GameService>()("GameService", {
   }),
 }) {}
 
-function createSessionStoreClient(gameSessionStore: GameSessionStore): GameSessionStoreClient {
-  return {
-    getGameSession: (sessionId) => Effect.runPromise(gameSessionStore.getGameSession(sessionId)),
-    createGameSession: (envelope) =>
-      Effect.runPromise(gameSessionStore.createGameSession(envelope)),
-    updateGameSession: (input) =>
-      Effect.runPromise(gameSessionStore.updateGameSession(input)),
-    resetGameSessionsForTests: () =>
-      Effect.runPromise(gameSessionStore.resetGameSessionsForTests()),
-  };
-}
-
 function tryGamePromise<A>(thunk: () => Promise<A>): Effect.Effect<A, GameServiceError> {
   return Effect.tryPromise({
     try: thunk,
-    catch: toGameServiceError,
+    catch: (error) => toGameServiceError(error),
   });
 }
 

--- a/packages/api/src/features/game/session-join.ts
+++ b/packages/api/src/features/game/session-join.ts
@@ -1,7 +1,8 @@
+import { Effect } from "effect";
 import {
+  GameSessionStore,
+  type GameSessionEnvelope,
   type GameSessionStoreClient,
-  getGameSession,
-  updateGameSession,
 } from "@reaping/redis";
 
 import {
@@ -13,9 +14,20 @@ import {
 } from "./wallet.js";
 
 const MAX_JOIN_RETRIES = 3;
-const defaultGameSessionStore: SessionJoinStore = {
-  getGameSession,
-  updateGameSession,
+
+type UpdateGameSessionInput = Parameters<GameSessionStoreClient["updateGameSession"]>[0];
+
+type SessionJoinStore = Pick<GameSessionStoreClient, "getGameSession" | "updateGameSession">;
+type SessionJoinEffectStore<R = never> = {
+  getGameSession(sessionId: string): Effect.Effect<GameSessionEnvelope | null, unknown, R>;
+  updateGameSession(
+    input: UpdateGameSessionInput,
+  ): Effect.Effect<GameSessionEnvelope, unknown, R>;
+};
+
+const defaultGameSessionEffectStore: SessionJoinEffectStore<GameSessionStore> = {
+  getGameSession: GameSessionStore.getGameSession,
+  updateGameSession: GameSessionStore.updateGameSession,
 };
 
 export type JoinGameSessionInput = {
@@ -26,90 +38,154 @@ export type JoinGameSessionInput = {
 };
 
 export async function joinGameSession(input: JoinGameSessionInput): Promise<ParticipantWalletState> {
-  return createSessionJoinApi(defaultGameSessionStore).joinGameSession(input);
+  return Effect.runPromise(
+    createSessionJoinEffectApi(defaultGameSessionEffectStore)
+      .joinGameSession(input)
+      .pipe(Effect.provide(GameSessionStore.Default)),
+  );
 }
 
 export async function getParticipantWallet(input: {
   sessionId: string;
   userId: string;
 }): Promise<ParticipantWalletState | null> {
-  return createSessionJoinApi(defaultGameSessionStore).getParticipantWallet(input);
+  return Effect.runPromise(
+    createSessionJoinEffectApi(defaultGameSessionEffectStore)
+      .getParticipantWallet(input)
+      .pipe(Effect.provide(GameSessionStore.Default)),
+  );
 }
 
-type SessionJoinStore = Pick<GameSessionStoreClient, "getGameSession" | "updateGameSession">;
-
 export function createSessionJoinApi(store: SessionJoinStore) {
+  const effectApi = createSessionJoinEffectApi(liftSessionJoinStore(store));
+
   return {
-    joinGameSession: async (input: JoinGameSessionInput): Promise<ParticipantWalletState> => {
-      for (let attempt = 0; attempt < MAX_JOIN_RETRIES; attempt += 1) {
-        const envelope = await getRequiredSession(store, input.sessionId);
-        const existingWallet = getParticipantWalletState(envelope, input.userId);
-
-        if (existingWallet !== null) {
-          return existingWallet;
-        }
-
-        const joinedAt = input.joinedAt ?? new Date().toISOString();
-        const nextWalletState = buildParticipantWalletState({
-          currentRound: envelope.round,
-          joinedAt,
-          sessionStatus: envelope.status,
-          userId: input.userId,
-          random: input.random,
-        });
-
-        try {
-          const updated = await store.updateGameSession({
-            sessionId: input.sessionId,
-            expectedVersion: envelope.version,
-            update: (current) => ({
-              ...upsertParticipantWalletState(current, nextWalletState),
-              version: current.version + 1,
-            }),
-          });
-          const persistedWallet = getParticipantWalletState(updated, input.userId);
-
-          if (persistedWallet === null) {
-            throw new Error("joined participant wallet was not persisted");
-          }
-
-          return persistedWallet;
-        } catch (error) {
-          if (isVersionMismatch(error)) {
-            continue;
-          }
-
-          throw error;
-        }
-      }
-
-      throw new Error("failed to join game session after retrying version conflicts");
-    },
-    getParticipantWallet: async (input: {
+    joinGameSession: (input: JoinGameSessionInput): Promise<ParticipantWalletState> =>
+      Effect.runPromise(effectApi.joinGameSession(input)),
+    getParticipantWallet: (input: {
       sessionId: string;
       userId: string;
-    }): Promise<ParticipantWalletState | null> => {
-      const envelope = await store.getGameSession(input.sessionId);
-
-      if (envelope === null) {
-        return null;
-      }
-
-      return getParticipantWalletState(envelope, input.userId);
-    },
+    }): Promise<ParticipantWalletState | null> =>
+      Effect.runPromise(effectApi.getParticipantWallet(input)),
   };
 }
 
-async function getRequiredSession(store: SessionJoinStore, sessionId: string) {
-  const envelope = await store.getGameSession(sessionId);
+export function createSessionJoinEffectApi<R>(store: SessionJoinEffectStore<R>) {
+  const joinGameSession = Effect.fn("GameSessionJoin.joinGameSession")(function* (
+    input: JoinGameSessionInput,
+  ) {
+    return yield* attemptJoin(store, input, 0);
+  });
 
-  if (envelope === null) {
-    throw new Error("game session not found");
-  }
+  const getParticipantWallet = Effect.fn("GameSessionJoin.getParticipantWallet")(function* (input: {
+    sessionId: string;
+    userId: string;
+  }) {
+    const envelope = yield* store.getGameSession(input.sessionId);
 
-  return envelope;
+    if (envelope === null) {
+      return null;
+    }
+
+    return getParticipantWalletState(envelope, input.userId);
+  });
+
+  return {
+    joinGameSession,
+    getParticipantWallet,
+  };
+}
+
+function attemptJoin<R>(
+  store: SessionJoinEffectStore<R>,
+  input: JoinGameSessionInput,
+  attempt: number,
+): Effect.Effect<ParticipantWalletState, unknown, R> {
+  return Effect.gen(function* () {
+    if (attempt >= MAX_JOIN_RETRIES) {
+      return yield* Effect.fail(
+        new Error("failed to join game session after retrying version conflicts"),
+      );
+    }
+
+    const envelope = yield* getRequiredSessionEffect(store, input.sessionId);
+    const existingWallet = getParticipantWalletState(envelope, input.userId);
+
+    if (existingWallet !== null) {
+      return existingWallet;
+    }
+
+    const joinedAt = input.joinedAt ?? new Date().toISOString();
+    const nextWalletState = buildParticipantWalletState({
+      currentRound: envelope.round,
+      joinedAt,
+      sessionStatus: envelope.status,
+      userId: input.userId,
+      random: input.random,
+    });
+
+    const updated = yield* store
+      .updateGameSession({
+        sessionId: input.sessionId,
+        expectedVersion: envelope.version,
+        update: (current) => ({
+          ...upsertParticipantWalletState(current, nextWalletState),
+          version: current.version + 1,
+        }),
+      })
+      .pipe(
+        Effect.map((nextEnvelope) => ({
+          kind: "updated" as const,
+          envelope: nextEnvelope,
+        })),
+        Effect.catchIf(isVersionMismatch, () =>
+          Effect.succeed({
+            kind: "retry" as const,
+          }),
+        ),
+      );
+
+    if (updated.kind === "retry") {
+      return yield* attemptJoin(store, input, attempt + 1);
+    }
+
+    const persistedWallet = getParticipantWalletState(updated.envelope, input.userId);
+
+    if (persistedWallet === null) {
+      return yield* Effect.fail(new Error("joined participant wallet was not persisted"));
+    }
+
+    return persistedWallet;
+  });
+}
+
+function getRequiredSessionEffect<R>(store: SessionJoinEffectStore<R>, sessionId: string) {
+  return Effect.gen(function* () {
+    const envelope = yield* store.getGameSession(sessionId);
+
+    if (envelope === null) {
+      return yield* Effect.fail(new Error("game session not found"));
+    }
+
+    return envelope;
+  });
 }
 
 function isVersionMismatch(error: unknown): boolean {
   return error instanceof Error && error.message === "version mismatch";
+}
+
+function liftSessionJoinStore(store: SessionJoinStore): SessionJoinEffectStore {
+  return {
+    getGameSession: (sessionId) =>
+      Effect.tryPromise({
+        try: () => store.getGameSession(sessionId),
+        catch: (error) => error,
+      }),
+    updateGameSession: (input) =>
+      Effect.tryPromise({
+        try: () => store.updateGameSession(input),
+        catch: (error) => error,
+      }),
+  };
 }

--- a/packages/api/src/features/game/wallet.ts
+++ b/packages/api/src/features/game/wallet.ts
@@ -98,9 +98,9 @@ export function upsertParticipantWalletState(
 export function parseParticipantWalletState(value: JsonObject): ParticipantWalletState | null {
   const userId = getString(value.userId);
   const role = value.role === "spectator" ? value.role : null;
-  const walletBalance = getInteger(value.walletBalance);
-  const lockedFunds = getInteger(value.lockedFunds);
-  const availableBalance = getInteger(value.availableBalance);
+  const walletBalance = getNumber(value.walletBalance);
+  const lockedFunds = getNumber(value.lockedFunds);
+  const availableBalance = getNumber(value.availableBalance);
   const joinedAt = getString(value.joinedAt);
   const eligibleFromRound = getInteger(value.eligibleFromRound);
   const isDead = getBoolean(value.isDead);
@@ -176,6 +176,10 @@ function getString(value: JsonValue | undefined): string | null {
 
 function getInteger(value: JsonValue | undefined): number | null {
   return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function getNumber(value: JsonValue | undefined): number | null {
+  return typeof value === "number" ? value : null;
 }
 
 function getBoolean(value: JsonValue | undefined): boolean | null {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,18 +1,19 @@
 import { Elysia } from "elysia"
 
-import { authPlugin } from "./modules/http/auth-plugin.js"
+import { createAuthPlugin } from "./modules/http/auth-plugin.js"
 import { httpTransportPlugin } from "./modules/http/transport-plugin.js"
 import { demoDomain } from "./features/demo/index.js"
 import { gameDomain } from "./features/game/index.js"
 
 export interface CreateAppOptions {
   corsOrigin: string
+  allowTestAuthHeaders?: boolean
 }
 
-export const createApp = ({ corsOrigin }: CreateAppOptions) =>
+export const createApp = ({ corsOrigin, allowTestAuthHeaders = false }: CreateAppOptions) =>
   new Elysia()
     .use(httpTransportPlugin(corsOrigin))
-    .use(authPlugin)
+    .use(createAuthPlugin({ allowTestAuthHeaders }))
     .use(demoDomain)
     .use(gameDomain)
     .get("/health", () => "OK")

--- a/packages/api/src/modules/http/auth-plugin.ts
+++ b/packages/api/src/modules/http/auth-plugin.ts
@@ -3,21 +3,32 @@ import { auth, getAuthSessionFromHeaders } from "@reaping/auth"
 
 import { mapHttpMethodError } from "./transport-plugin.js"
 
-export const authPlugin = new Elysia({ name: "auth" }).all(
-  "/api/auth/*",
-  async (context: Context) => {
-    const methodError = mapHttpMethodError(context)
+export type AuthPluginOptions = {
+  allowTestAuthHeaders?: boolean
+}
 
-    if (methodError !== null) {
-      return methodError
-    }
+export const createAuthPlugin = ({ allowTestAuthHeaders = false }: AuthPluginOptions = {}) =>
+  new Elysia({ name: "auth" }).all(
+    "/api/auth/*",
+    async (context: Context) => {
+      const methodError = mapHttpMethodError(context)
 
-    return auth.handler(context.request)
-  },
-)
+      if (methodError !== null) {
+        return methodError
+      }
 
-export async function resolveAuthUserFromRequest(request: Request) {
-  if (process.env.NODE_ENV === "test") {
+      return auth.handler(context.request)
+    },
+  )
+    .decorate("authOptions", {
+      allowTestAuthHeaders,
+    })
+
+export async function resolveAuthUserFromRequest(
+  request: Request,
+  { allowTestAuthHeaders = false }: AuthPluginOptions = {},
+) {
+  if (allowTestAuthHeaders) {
     const testUserId = request.headers.get("x-test-user-id")
 
     if (testUserId !== null && testUserId.length > 0) {

--- a/packages/api/src/modules/http/run-effect.ts
+++ b/packages/api/src/modules/http/run-effect.ts
@@ -1,0 +1,14 @@
+import { Effect } from "effect";
+
+import { DemoService } from "../../features/demo/service.js";
+import { GameService } from "../../features/game/service.js";
+import { AppRuntime } from "../../runtime.js";
+
+export function runAppEffect<A, E>(effect: Effect.Effect<A, E, DemoService | GameService>) {
+  return Effect.runPromise(
+    effect.pipe(
+      Effect.either,
+      Effect.provide(AppRuntime),
+    ),
+  );
+}

--- a/packages/api/src/modules/http/transport-plugin.ts
+++ b/packages/api/src/modules/http/transport-plugin.ts
@@ -1,3 +1,4 @@
+import { Effect } from "effect"
 import { cors } from "@elysiajs/cors"
 import { Elysia, type Context, status } from "elysia"
 
@@ -27,7 +28,7 @@ export const httpTransportPlugin = (corsOrigin: string) =>
       }),
     )
     .onError(({ error, set }) => {
-      console.error(error)
+      void Effect.runFork(Effect.logError("Unhandled HTTP error", { error }))
       set.status = DEFAULT_HTTP_ERROR_STATUS
 
       return {


### PR DESCRIPTION
Follow-up to merged TOR-39 work.

This PR addresses the post-merge audit findings:
- fix settlement summary accounting across CAS retries
- preserve wallet participants after fractional payouts
- add focused regression coverage for both cases
- centralize Effect route execution and explicit test auth configuration
- move web dashboard auth reads to a server-only Better Auth helper
- mark server-only Eden SSR client correctly and update tests

Validation:
- bun test packages/api/src/features/game/betting.test.ts packages/api/src/features/game/session-join.test.ts packages/api/src/features/game/pricing.test.ts packages/redis/src/index.test.ts apps/web/src/modules/api/eden.server.test.ts
- bun run check-types --filter=@reaping/api --filter=@reaping/server --filter=@reaping/web
- bun run test:server